### PR TITLE
Make celery task work by default

### DIFF
--- a/celery_bungiesearch/tasks/celerybungie.py
+++ b/celery_bungiesearch/tasks/celerybungie.py
@@ -7,7 +7,7 @@ CeleryTask = get_celery_task()
 class CeleryBungieTask(CeleryTask):
 
     def delay(self, *args, **kwargs):
-        if 'queue' not in kwargs and settings.CELERY_BUNGIESEARCH_QUEUE:
+        if 'queue' not in kwargs and hasattr(settings, 'CELERY_BUNGIESEARCH_QUEUE'):
             kwargs['queue'] = settings.CELERY_BUNGIESEARCH_QUEUE
 
         super(CeleryBungieTask, self).delay(*args, **kwargs)

--- a/celery_bungiesearch/utils.py
+++ b/celery_bungiesearch/utils.py
@@ -50,4 +50,8 @@ def get_model_index(model):
 
 
 def get_model_indexing_query(model):
-    return Bungiesearch().get_model_index(model.__name__).Meta.indexing_query
+    return getattr(
+        Bungiesearch().get_model_index(model.__name__).Meta,
+        'indexing_query',
+        model.objects.all()
+    )


### PR DESCRIPTION
The celery task fails for me beacuse of a missing setting which should be optional as per the docs.
Also, do not rely on `Meta.indexing_query` being set on the `ModelIndex` beacause it is also optional.
