### PR TITLE
Handle 404 action failures properly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 celery==3.1.18
-bungiesearch==1.2.1
+bungiesearch==1.2.2
 Django==1.8.3
 django-celery==3.1.16
 flake8==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = (1, 1, 4)
+VERSION = (1, 1, 5)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ __versionstr__ = '.'.join(map(str, VERSION))
 
 
 install_requires = [
-    'bungiesearch>=1.2.1',
+    'bungiesearch>=1.2.2',
     'celery==3.1.18',
     'Django>=1.4.3',
 ]


### PR DESCRIPTION
The client will crash in some cases when bulk deleting documents that are not found in the index. For failed actions, elastic search will report BulkIndex errors instead of transport errors. You can see the errors below
- BulkIndexError: https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/helpers/__init__.py#L114
- TransportError: https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/helpers/__init__.py#L88
