### PR TITLE
Removed djcelery_transactions requirement

### DIFF
--- a/celery_bungiesearch/utils.py
+++ b/celery_bungiesearch/utils.py
@@ -1,12 +1,8 @@
 from bungiesearch import Bungiesearch
+from celery.task import Task as CeleryTask
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
-
-if not getattr(settings, 'CELERY_ALWAYS_EAGER', False):
-    from djcelery_transactions import PostTransactionTask as CeleryTask
-else:
-    from celery.task import Task as CeleryTask
 
 
 def get_celery_task():


### PR DESCRIPTION
This delays celery tasks for indexing models to the end of the request for most users but did not specify the dependency in requirements.txt so it would break. I removed this all together, which could be a breaking change for people but should not be the default behavior.

If users want this, they can specify this behavior in their custom task using the setting settings.CELERY_BUNGIESEARCH_CUSTOM_TASK
