### PR TITLE
do not force index refresh because these are tasks

### DIFF
--- a/celery_bungiesearch/tasks/bulkdelete.py
+++ b/celery_bungiesearch/tasks/bulkdelete.py
@@ -1,9 +1,9 @@
-from .celerybungie import CeleryBungieTask
 from bungiesearch import Bungiesearch
 from bungiesearch.utils import update_index
-
 from elasticsearch import TransportError
 from elasticsearch.helpers import BulkIndexError
+
+from .celerybungie import CeleryBungieTask
 
 
 class BulkDeleteTask(CeleryBungieTask):
@@ -13,7 +13,8 @@ class BulkDeleteTask(CeleryBungieTask):
         buffer_size = settings.get('BUFFER_SIZE', 100)
 
         try:
-            update_index(instance_pks, model.__name__, action='delete', bulk_size=buffer_size)
+            update_index(instance_pks, model.__name__,
+                action='delete', bulk_size=buffer_size, refresh=False)
 
         except BulkIndexError as e:
             for error in e.errors:

--- a/celery_bungiesearch/tasks/celerybungie.py
+++ b/celery_bungiesearch/tasks/celerybungie.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+
 from ..utils import get_celery_task
 
 CeleryTask = get_celery_task()

--- a/celery_bungiesearch/tasks/celeryindex.py
+++ b/celery_bungiesearch/tasks/celeryindex.py
@@ -1,6 +1,6 @@
-from ..utils import get_model_indexing_query
 from bungiesearch.utils import delete_index_item, update_index
 
+from ..utils import get_model_indexing_query
 from .celerybungie import CeleryBungieTask
 
 
@@ -22,9 +22,9 @@ class CeleryIndexTask(CeleryBungieTask):
             should_index = indexing_query.filter(pk=instance.pk).exists()
 
             if should_index:
-                update_index([instance], model_name)
+                update_index([instance], model_name, refresh=False)
             else:
                 delete_index_item(instance, model_name)
 
         elif action == 'delete':
-            delete_index_item(instance, model_name)
+            delete_index_item(instance, model_name, refresh=False)

--- a/tests/core/test_celery_bungiesearch.py
+++ b/tests/core/test_celery_bungiesearch.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytz
+from bungiesearch import Bungiesearch
 from bungiesearch.signals import get_signal_processor
 from django.core.management import call_command
 from django.test import TestCase
@@ -24,8 +25,9 @@ class SignalTest(TestCase):
         call_command('search_index', action='delete', confirmed='guilty-as-charged')
 
     def assertResultsLength(self, results, expected):
-        msg = 'Search did not return exactly 2 users (got {})'.format(len(results))
-        self.assertEqual(len(results), expected, msg)
+        length = len(results)
+        msg = 'Search did not return exactly %s items (got %s)' % (expected, length)
+        self.assertEqual(length, expected, msg)
 
     def test_signal_processor(self):
         self.assertTrue(isinstance(signal_processor, CelerySignalProcessor),
@@ -55,6 +57,7 @@ class SignalTest(TestCase):
         }
 
         User.objects.create(**jane_doe)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         single_result_check = User.objects.search.query('match', name='Doe')
 
@@ -64,12 +67,14 @@ class SignalTest(TestCase):
             error_message_contains('Doe', 'name', 'Jane Doe', single_result_check[0].name))
 
         User.objects.create(**john_doe)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         two_result_check = User.objects.search.query('match', _all='doe')
         self.assertEqual(len(two_result_check), 2,
             error_message_len('Doe', 'user_id', 2, len(two_result_check)))
 
         User.objects.create(**cryptography)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         no_additional_result_check = User.objects.search.query('match', name='Doe')
         single_result_check = User.objects.search.query('match', name='Alice')
@@ -100,20 +105,24 @@ class SignalTest(TestCase):
         first_user = User.objects.create(**clinton)
         second_user = User.objects.create(**obama)
         third_user = User.objects.create(**bush)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         search_all = User.objects.search.query('match', updated=self.updated)
 
         self.assertEqual(len(search_all), 3,
             'Search did not return exactly 3 users (got {})'.format(len(search_all)))
         first_user.delete()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 2,
             'Search did not return exactly 2 users (got {})'.format(len(search_all)))
         second_user.delete()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 1,
             'Search did not return exactly 1 user (got {})'.format(len(search_all)))
         third_user.delete()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 0,
             'Search did not return exactly 0 users (got {})'.format(len(search_all)))
@@ -131,6 +140,7 @@ class SignalTest(TestCase):
         }
 
         first_user = User.objects.create(**berkeley)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         search_all = User.objects.search.query('match', updated=self.updated)
 
@@ -138,11 +148,13 @@ class SignalTest(TestCase):
             'Search did not return exactly 1 user (got {})'.format(len(search_all)))
 
         second_user = User.objects.create(**stanford)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 2,
             'Search did not return exactly 2 users (got {})'.format(len(search_all)))
 
         second_user.delete()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 1,
             'Search did not return exactly 1 user (got {})'.format(len(search_all)))
@@ -153,6 +165,7 @@ class SignalTest(TestCase):
 
         first_user.user_id = 'Beat Stanford'
         first_user.save()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(User.objects.search.query('match', _all='Beat Stanford')), 1,
             'Search did not return exactly 1 user (got {})'.format(len(search_all)))
@@ -161,6 +174,7 @@ class SignalTest(TestCase):
             .format(search_all[0].user_id))
 
         first_user.delete()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         self.assertEqual(len(search_all), 0,
             'Search did not return exactly 1 user (got {})'.format(len(search_all)))
@@ -179,12 +193,14 @@ class SignalTest(TestCase):
 
         first_user = User.objects.create(**peanut_butter)
         second_user = User.objects.create(**peanut_butter_and_jelly)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         two_result_check = User.objects.search.query('match', name='Peanut')
         self.assertResultsLength(two_result_check, 2)
 
         model_item_pks = [first_user.pk, second_user.pk]
         BulkDeleteTask().delay(User, model_item_pks)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         empty_set_check = User.objects.search.query('match', name='Peanut')
         self.assertResultsLength(empty_set_check, 0)
@@ -203,6 +219,7 @@ class SignalTest(TestCase):
 
         User.objects.create(**fake)
         discovered_user = User.objects.create(**discovered)
+        Bungiesearch().get_es_instance().indices.refresh()
 
         # Check to ensure that user_id fake is excluded as dictated by index_queryset
         one_result_check = User.objects.search.query('match', name='fraud')
@@ -211,6 +228,7 @@ class SignalTest(TestCase):
 
         discovered_user.user_id = 'fake'
         discovered_user.save()
+        Bungiesearch().get_es_instance().indices.refresh()
 
         # Check to ensure same result on a change and save operation
         empty_set_check = User.objects.search.query('match', name='fraud')


### PR DESCRIPTION
- resolve the `get_update_task` only once during `__init__` of the signal processor
- use `refresh=False` because these are background tasks that dont have consistency guarantees anyways, so no need to force cluster wide sync
